### PR TITLE
fix: not scrolling all the way

### DIFF
--- a/extension/dist/content.js
+++ b/extension/dist/content.js
@@ -126,8 +126,7 @@ async function scrollToNextShort() {
     if (nextVideoParent) {
         nextVideoParent.scrollIntoView({
             behavior: "smooth",
-            block: "center",
-            inline: "center",
+            block: "end",
         });
     }
     else {


### PR DESCRIPTION
Recently, the automatic scroll didn't always scroll all the way to the next video. Instead, it got stuck three-fourths of the way. This change fixes the issue by scrolling all the way to the end.