### PR TITLE
fix non stop scrolling because comment count selecter has changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 extension.zip
+.idea/

--- a/extension/dist/content.js
+++ b/extension/dist/content.js
@@ -11,7 +11,7 @@ const DISLIKE_BUTTON_SELECTOR = "#dislike-button button";
 const COMMENTS_SELECTOR = "ytd-engagement-panel-section-list-renderer[target-id='engagement-panel-comments-section']";
 const LIKES_COUNT_SELECTOR = "#factoids > factoid-renderer:nth-child(1) > div > span.ytwFactoidRendererValue > span";
 const VIEW_COUNT_SELECTOR = "#factoids > view-count-factoid-renderer > factoid-renderer > div > span.ytwFactoidRendererValue > span";
-const COMMENTS_COUNT_SELECTOR = "#comments-button > ytd-button-renderer > yt-button-shape > label > div > span";
+const COMMENTS_COUNT_SELECTOR = "#button-bar > reel-action-bar-view-model > button-view-model:nth-of-type(1) > label > div > span";
 const DESCRIPTION_TAGS_SELECTOR = "#title > yt-formatted-string > a";
 const AUTHOUR_NAME_SELECTOR = "#metapanel > yt-reel-metapanel-view-model > div:nth-child(1) > yt-reel-channel-bar-view-model > span > a";
 const AUTHOUR_NAME_SELECTOR_2 = "#metapanel > yt-reel-metapanel-view-model > div:nth-child(2) > yt-reel-channel-bar-view-model > span > a";
@@ -117,6 +117,7 @@ async function checkForNewShort() {
         // Add event listener to the current video element
         console.log("[Auto Youtube Shorts Scroller] Adding event listener to video element...");
         currentVideoElement.addEventListener("ended", shortEnded);
+        console.log(currentVideoElement.duration);
         currentVideoElement._hasEndEvent = true;
         // Check if the current short has metadata
         const isMetaDataHydrated = (selector) => {

--- a/src/content.ts
+++ b/src/content.ts
@@ -15,7 +15,7 @@ const LIKES_COUNT_SELECTOR =
 const VIEW_COUNT_SELECTOR =
    "#factoids > view-count-factoid-renderer > factoid-renderer > div > span.ytwFactoidRendererValue > span";
 const COMMENTS_COUNT_SELECTOR =
-   "#comments-button > ytd-button-renderer > yt-button-shape > label > div > span";
+	 "#button-bar > reel-action-bar-view-model > button-view-model:nth-of-type(1) > label > div > span";
 const DESCRIPTION_TAGS_SELECTOR = "#title > yt-formatted-string > a";
 const AUTHOUR_NAME_SELECTOR =
    "#metapanel > yt-reel-metapanel-view-model > div:nth-child(1) > yt-reel-channel-bar-view-model > span > a";


### PR DESCRIPTION
YouTube has changed the container for comment causing the old comment selector not working and causing the extension to keep skipping short and move to next one